### PR TITLE
feat: add open_ticket_in_browser tool

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,9 @@ MCP (Model Context Protocol) server that wraps the `jira-cli` command-line tool 
 6. **move_ticket** - Move tickets between statuses
    - Maps lowercase status names to Jira status names
 
+7. **open_ticket_in_browser** - Open tickets in default web browser
+   - Uses `jira open` command to launch browser
+
 ## Technical Details
 
 - **Runtime**: Bun

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ MCP (Model Context Protocol) server that wraps the `jira-cli` command-line tool 
 - **add_comment** - Add comments to tickets with Markdown support
 - **assign_to_me** - Assign tickets to the current user
 - **move_ticket** - Move tickets between different statuses
+- **open_ticket_in_browser** - Open a Jira ticket in the default web browser
 
 ## Prerequisites
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,10 @@ import { getTicket, getTicketSchema } from "./tools/getTicket.js";
 import { listTickets, listTicketsSchema } from "./tools/listTickets.js";
 import { moveTicket, moveTicketSchema } from "./tools/moveTicket.js";
 import {
+  openTicketInBrowser,
+  openTicketInBrowserSchema,
+} from "./tools/openTicketInBrowser.js";
+import {
   updateTicketDescription,
   updateTicketDescriptionSchema,
 } from "./tools/updateTicketDescription.js";
@@ -223,6 +227,38 @@ server.tool("move_ticket", moveTicketSchema.shape, async (params) => {
     throw error;
   }
 });
+
+// Open ticket in browser tool
+server.tool(
+  "open_ticket_in_browser",
+  openTicketInBrowserSchema.shape,
+  async (params) => {
+    try {
+      const result = await openTicketInBrowser(params);
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: result.message,
+          },
+        ],
+      };
+    } catch (error) {
+      if (error instanceof JiraCliError) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Error: ${error.message}\n\nMake sure jira-cli is installed and authenticated.`,
+            },
+          ],
+        };
+      }
+      throw error;
+    }
+  },
+);
 
 async function main() {
   const transport = new StdioServerTransport();

--- a/src/tools/openTicketInBrowser.ts
+++ b/src/tools/openTicketInBrowser.ts
@@ -1,0 +1,31 @@
+import { z } from "zod";
+import { executeJiraCommand } from "../utils/jiraExecutor.js";
+
+export const openTicketInBrowserSchema = z.object({
+  ticketKey: z.string().describe("Jira ticket key (e.g., PROJ-123)"),
+});
+
+export type OpenTicketInBrowserParams = z.infer<
+  typeof openTicketInBrowserSchema
+>;
+
+export async function openTicketInBrowser(
+  params: OpenTicketInBrowserParams,
+): Promise<{ message: string }> {
+  const { ticketKey } = params;
+
+  // Build command arguments
+  const args = ["open", ticketKey];
+
+  const result = await executeJiraCommand(args);
+
+  if (result.exitCode !== 0) {
+    throw new Error(
+      `Failed to open ticket ${ticketKey} in browser: ${result.stderr}`,
+    );
+  }
+
+  return {
+    message: `Successfully opened ticket ${ticketKey} in browser`,
+  };
+}

--- a/tests/integration/openTicketInBrowser.integration.test.ts
+++ b/tests/integration/openTicketInBrowser.integration.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+import { openTicketInBrowser } from "../../src/tools/openTicketInBrowser";
+
+const isIntegrationTest = process.env.INTEGRATION_TEST === "true";
+
+const isJiraAvailable = async (): Promise<boolean> => {
+  try {
+    const { executeJiraCommand } = await import("../../src/utils/jiraExecutor");
+    const result = await executeJiraCommand(["version"]);
+    return result.exitCode === 0;
+  } catch {
+    return false;
+  }
+};
+
+const shouldRunIntegrationTests =
+  isIntegrationTest && (await isJiraAvailable());
+
+describe.skipIf(!shouldRunIntegrationTests)(
+  "openTicketInBrowser integration tests",
+  () => {
+    test.skipIf(!process.env.JIRA_CLI_MCP_TEST_TICKET)(
+      "should work with real jira-cli",
+      async () => {
+        // Use the ticket from environment variable
+        const ticketKey = process.env.JIRA_CLI_MCP_TEST_TICKET as string;
+
+        // Open the ticket in browser
+        const result = await openTicketInBrowser({
+          ticketKey: ticketKey,
+        });
+
+        // Verify result structure
+        expect(result).toHaveProperty("message");
+        expect(result.message).toBe(
+          `Successfully opened ticket ${ticketKey} in browser`,
+        );
+      },
+    );
+
+    test("should handle invalid ticket key with real jira-cli", async () => {
+      // Note: jira open command might not always fail for invalid tickets
+      // It may open the project page instead
+      // This test verifies the command executes without errors
+      const result = await openTicketInBrowser({
+        ticketKey: "INVALID-999999",
+      });
+
+      expect(result).toHaveProperty("message");
+      expect(result.message).toContain("Successfully opened");
+    });
+  },
+);

--- a/tests/openTicketInBrowser.test.ts
+++ b/tests/openTicketInBrowser.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+describe("openTicketInBrowser", () => {
+  afterEach(() => {
+    mock.restore();
+  });
+
+  // Mock tests using recorded output
+  describe("unit tests (mocked)", () => {
+    test("should successfully open ticket in browser", async () => {
+      const mockExecuteJiraCommand = mock(async () => ({
+        stdout: "",
+        stderr: "",
+        exitCode: 0,
+      }));
+
+      mock.module("../src/utils/jiraExecutor", () => ({
+        executeJiraCommand: mockExecuteJiraCommand,
+      }));
+
+      const { openTicketInBrowser } = await import(
+        "../src/tools/openTicketInBrowser"
+      );
+      const result = await openTicketInBrowser({
+        ticketKey: "TEST-123",
+      });
+
+      expect(mockExecuteJiraCommand).toHaveBeenCalledWith(["open", "TEST-123"]);
+      expect(result.message).toBe(
+        "Successfully opened ticket TEST-123 in browser",
+      );
+    });
+
+    test("should handle jira command failure", async () => {
+      const mockExecuteJiraCommand = mock(async () => ({
+        stdout: "",
+        stderr:
+          "Issue TEST-999 does not exist or you do not have permission to see it.",
+        exitCode: 1,
+      }));
+
+      mock.module("../src/utils/jiraExecutor", () => ({
+        executeJiraCommand: mockExecuteJiraCommand,
+      }));
+
+      const { openTicketInBrowser } = await import(
+        "../src/tools/openTicketInBrowser"
+      );
+      await expect(
+        openTicketInBrowser({
+          ticketKey: "TEST-999",
+        }),
+      ).rejects.toThrow("Failed to open ticket TEST-999 in browser");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Implements new MCP tool to open Jira tickets in the default web browser
- Uses the `jira open` command which launches the browser with the ticket URL
- Closes #1

## Test plan
- [x] Unit tests added and passing
- [x] Integration tests added 
- [x] Manual testing confirmed browser opens with ticket
- [x] Documentation updated (README.md and CLAUDE.md)
- [x] All CI checks pass