### PR TITLE
feat: add dual distribution via npm and binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,125 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  build-binaries:
+    strategy:
+      matrix:
+        include:
+          - os: macos-latest
+            target: darwin-arm64
+            name: jira-cli-mcp-darwin-arm64
+          - os: macos-latest
+            target: darwin-x64
+            name: jira-cli-mcp-darwin-x64
+          - os: ubuntu-latest
+            target: linux-x64
+            name: jira-cli-mcp-linux-x64
+          - os: ubuntu-latest
+            target: linux-arm64
+            name: jira-cli-mcp-linux-arm64
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Build binary
+        run: bun build --compile --target=bun-${{ matrix.target }} --minify --sourcemap=none --outfile=${{ matrix.name }} src/index.ts
+
+      - name: Compress binary
+        run: |
+          tar -czf ${{ matrix.name }}.tar.gz ${{ matrix.name }}
+          ls -lh ${{ matrix.name }}*
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.name }}
+          path: ${{ matrix.name }}.tar.gz
+
+  create-release:
+    needs: build-binaries
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: ./artifacts
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: true
+          prerelease: false
+
+      - name: Upload Release Assets
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          for file in artifacts/*/*.tar.gz; do
+            asset_name=$(basename "$file")
+            echo "Uploading $asset_name"
+            gh release upload ${{ github.ref_name }} "$file" --clobber
+          done
+
+  publish-npm:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Build for npm
+        run: bun run build:prod
+
+      - name: Update shebang for Node.js
+        run: |
+          echo '#!/usr/bin/env node' > dist/index.js.tmp
+          cat dist/index.js >> dist/index.js.tmp
+          mv dist/index.js.tmp dist/index.js
+          chmod +x dist/index.js
+
+      - name: Test npm package
+        run: |
+          npm pack
+          ls -lh *.tgz
+
+      - name: Publish to npm
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,10 @@ out
 dist
 *.tgz
 
+# compiled binaries
+jira-cli-mcp-*
+!jira-cli-mcp-*.tar.gz
+
 # code coverage
 coverage
 *.lcov

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,33 @@
+# Source files
+src/
+tests/
+
+# Config files
+.github/
+biome.json
+commitlint.config.js
+lefthook.yml
+tsconfig.json
+tsconfig.build.json
+CLAUDE.md
+
+# Build artifacts
+jira-cli-mcp-*
+*.tar.gz
+
+# Development files
+.git/
+.gitignore
+.npmignore
+node_modules/
+bun.lockb
+
+# IDE
+.idea/
+.vscode/
+.DS_Store
+
+# Logs and temp files
+*.log
+.env*
+coverage/

--- a/README.md
+++ b/README.md
@@ -64,13 +64,44 @@ Choose [mcp-atlassian](https://github.com/sooperset/mcp-atlassian) if you:
 
 ## Installation
 
+### Option 1: Install via npm (Recommended)
+
 ```bash
+# Install globally with npm
+npm install -g @choplin/jira-cli-mcp
+
+# Or with Bun
+bun install -g @choplin/jira-cli-mcp
+```
+
+### Option 2: Download Binary
+
+Download the pre-compiled binary for your platform from the [releases page](https://github.com/choplin/jira-cli-mcp/releases):
+
+- macOS (Apple Silicon): `jira-cli-mcp-darwin-arm64.tar.gz`
+- macOS (Intel): `jira-cli-mcp-darwin-x64.tar.gz`
+- Linux (x64): `jira-cli-mcp-linux-x64.tar.gz`
+- Linux (ARM64): `jira-cli-mcp-linux-arm64.tar.gz`
+
+```bash
+# Example for macOS (Apple Silicon)
+tar -xzf jira-cli-mcp-darwin-arm64.tar.gz
+chmod +x jira-cli-mcp-darwin-arm64
+sudo mv jira-cli-mcp-darwin-arm64 /usr/local/bin/jira-cli-mcp
+```
+
+### Option 3: Build from Source
+
+```bash
+git clone https://github.com/choplin/jira-cli-mcp.git
+cd jira-cli-mcp
 bun install
+bun run build:prod
 ```
 
 ## Setup for Claude Desktop
 
-### Option 1: Direct Path (Recommended for Development)
+### Option 1: Using npm Package (Lightest Option)
 
 Add to your `claude_desktop_config.json`:
 
@@ -78,53 +109,65 @@ Add to your `claude_desktop_config.json`:
 {
   "mcpServers": {
     "jira-cli": {
-      "command": "bun",
-      "args": ["run", "/path/to/jira-cli-mcp/src/index.ts"]
+      "command": "npx",
+      "args": ["@choplin/jira-cli-mcp"]
     }
   }
 }
 ```
 
-### Option 2: Built Version (Recommended for Production)
-
-1. Build the project:
-
-```bash
-cd /path/to/jira-cli-mcp
-bun install
-bun run build
-```
-
-2. Add to config:
-
-```json
-{
-  "mcpServers": {
-    "jira-cli": {
-      "command": "bun",
-      "args": ["run", "/path/to/jira-cli-mcp/dist/index.js"]
-    }
-  }
-}
-```
-
-### Option 3: Global Binary
-
-1. Create a binary wrapper:
-
-```bash
-cd /path/to/jira-cli-mcp
-bun build --compile --target=bun-darwin-arm64 --outfile=jira-cli-mcp src/index.ts
-sudo mv jira-cli-mcp /usr/local/bin/
-```
-
-2. Add to config:
+Or if installed globally:
 
 ```json
 {
   "mcpServers": {
     "jira-cli": {
       "command": "jira-cli-mcp"
+    }
+  }
+}
+```
+
+### Option 2: Using Pre-compiled Binary (No Dependencies)
+
+1. Download the binary for your platform from [releases](https://github.com/choplin/jira-cli-mcp/releases)
+2. Extract and move to your PATH:
+
+```bash
+tar -xzf jira-cli-mcp-darwin-arm64.tar.gz
+sudo mv jira-cli-mcp-darwin-arm64 /usr/local/bin/jira-cli-mcp
+```
+
+3. Add to config:
+
+```json
+{
+  "mcpServers": {
+    "jira-cli": {
+      "command": "jira-cli-mcp"
+    }
+  }
+}
+```
+
+### Option 3: Build from Source
+
+1. Clone and run directly:
+
+```bash
+git clone https://github.com/choplin/jira-cli-mcp.git
+cd jira-cli-mcp
+bun install
+```
+
+2. Add to config:
+
+```json
+{
+  "mcpServers": {
+    "jira-cli": {
+      "command": "bun",
+      "args": ["run", "/path/to/jira-cli-mcp/src/index.ts"]
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,15 +1,53 @@
 {
-  "name": "jira-cli-mcp",
+  "name": "@choplin/jira-cli-mcp",
   "version": "0.1.0",
+  "description": "MCP server that wraps jira-cli for AI assistants",
   "license": "Apache-2.0",
-  "module": "src/index.ts",
+  "author": "Akihiro Okuno",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/choplin/jira-cli-mcp.git"
+  },
+  "homepage": "https://github.com/choplin/jira-cli-mcp#readme",
+  "bugs": {
+    "url": "https://github.com/choplin/jira-cli-mcp/issues"
+  },
+  "keywords": [
+    "mcp",
+    "jira",
+    "jira-cli",
+    "modelcontextprotocol",
+    "ai",
+    "claude"
+  ],
+  "main": "dist/index.js",
+  "module": "dist/index.js",
   "type": "module",
-  "private": true,
+  "bin": {
+    "jira-cli-mcp": "dist/index.js"
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "start": "bun run src/index.ts",
     "dev": "bun --watch run src/index.ts",
     "build": "rm -rf dist && bun build --target=bun --outdir=dist --sourcemap src/index.ts",
+    "build:prod": "rm -rf dist && bun build --target=bun --outdir=dist --minify --sourcemap=none src/index.ts",
     "build:tsc": "rm -rf dist && tsc -p tsconfig.build.json",
+    "build:binary:darwin-arm64": "bun build --compile --target=bun-darwin-arm64 --minify --sourcemap=none --outfile=jira-cli-mcp-darwin-arm64 src/index.ts",
+    "build:binary:darwin-x64": "bun build --compile --target=bun-darwin-x64 --minify --sourcemap=none --outfile=jira-cli-mcp-darwin-x64 src/index.ts",
+    "build:binary:linux-x64": "bun build --compile --target=bun-linux-x64 --minify --sourcemap=none --outfile=jira-cli-mcp-linux-x64 src/index.ts",
+    "build:binary:linux-arm64": "bun build --compile --target=bun-linux-arm64 --minify --sourcemap=none --outfile=jira-cli-mcp-linux-arm64 src/index.ts",
+    "build:binaries": "bun run build:binary:darwin-arm64 && bun run build:binary:darwin-x64 && bun run build:binary:linux-x64 && bun run build:binary:linux-arm64",
     "test": "bun test tests/",
     "test:integration": "INTEGRATION_TEST=true bun test tests/integration/",
     "typecheck": "tsc --noEmit",


### PR DESCRIPTION
## Summary
- Set up dual distribution system for both npm package and pre-compiled binaries
- Users can now choose the installation method that best fits their needs

## Changes

### npm Package Distribution
- Configured as `@choplin/jira-cli-mcp` on npm registry
- Includes proper bin configuration for global installation
- Optimized package size with `.npmignore` (~37KB compressed)

### Binary Distribution
- Added build scripts for multiple platforms:
  - macOS (Intel & Apple Silicon)
  - Linux (x64 & ARM64)
- Pre-compiled binaries are ~55MB (includes Bun runtime)
- Zero runtime dependencies

### GitHub Actions Automation
- Created `release.yml` workflow for automated releases
- Triggers on version tags (e.g., `v0.1.0`)
- Automatically:
  - Builds binaries for all platforms
  - Creates GitHub release with artifacts
  - Publishes to npm registry

### Documentation Updates
- Reorganized installation section with three clear options
- Added comparison of each method's trade-offs
- Updated Claude Desktop setup instructions

## Installation Methods Comparison

| Method | Size | Dependencies | Best For |
|--------|------|--------------|----------|
| npm package | ~37KB (+ npm deps) | Requires Node.js | Developers with Node.js |
| Binary | ~55MB | None | Users without Node.js |
| Source | ~1MB | Requires Bun | Development/contribution |

## Next Steps
1. Set up `NPM_TOKEN` secret in repository settings
2. Create first release with `git tag v0.1.0 && git push origin v0.1.0`
3. Consider creating Homebrew formula for easier macOS installation