### PR TITLE
feat: add Homebrew distribution support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,12 +46,15 @@ jobs:
         run: |
           tar -czf ${{ matrix.name }}.tar.gz ${{ matrix.name }}
           ls -lh ${{ matrix.name }}*
+          shasum -a 256 ${{ matrix.name }}.tar.gz > ${{ matrix.name }}.tar.gz.sha256
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.name }}
-          path: ${{ matrix.name }}.tar.gz
+          path: |
+            ${{ matrix.name }}.tar.gz
+            ${{ matrix.name }}.tar.gz.sha256
 
   create-release:
     needs: build-binaries
@@ -123,3 +126,51 @@ jobs:
         run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  update-homebrew-tap:
+    needs: create-release
+    runs-on: ubuntu-latest
+    if: "!contains(github.ref, '-')"  # Only for stable releases
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: ./artifacts
+
+      - name: Extract SHA256 values
+        id: sha256
+        run: |
+          echo "darwin_arm64=$(cat artifacts/jira-cli-mcp-darwin-arm64/jira-cli-mcp-darwin-arm64.tar.gz.sha256 | awk '{print $1}')" >> $GITHUB_OUTPUT
+          echo "darwin_x64=$(cat artifacts/jira-cli-mcp-darwin-x64/jira-cli-mcp-darwin-x64.tar.gz.sha256 | awk '{print $1}')" >> $GITHUB_OUTPUT
+          echo "linux_arm64=$(cat artifacts/jira-cli-mcp-linux-arm64/jira-cli-mcp-linux-arm64.tar.gz.sha256 | awk '{print $1}')" >> $GITHUB_OUTPUT
+          echo "linux_x64=$(cat artifacts/jira-cli-mcp-linux-x64/jira-cli-mcp-linux-x64.tar.gz.sha256 | awk '{print $1}')" >> $GITHUB_OUTPUT
+
+      - name: Update Homebrew formula
+        run: |
+          VERSION="${GITHUB_REF#refs/tags/v}"
+          sed -i "s/version \".*\"/version \"$VERSION\"/" homebrew/jira-cli-mcp.rb
+          sed -i "s|download/v[0-9.]*|download/v$VERSION|g" homebrew/jira-cli-mcp.rb
+          sed -i "s/PLACEHOLDER_SHA256_DARWIN_ARM64/${{ steps.sha256.outputs.darwin_arm64 }}/" homebrew/jira-cli-mcp.rb
+          sed -i "s/PLACEHOLDER_SHA256_DARWIN_X64/${{ steps.sha256.outputs.darwin_x64 }}/" homebrew/jira-cli-mcp.rb
+          sed -i "s/PLACEHOLDER_SHA256_LINUX_ARM64/${{ steps.sha256.outputs.linux_arm64 }}/" homebrew/jira-cli-mcp.rb
+          sed -i "s/PLACEHOLDER_SHA256_LINUX_X64/${{ steps.sha256.outputs.linux_x64 }}/" homebrew/jira-cli-mcp.rb
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore: update Homebrew formula to v${{ github.ref_name }}"
+          title: "Update Homebrew formula to ${{ github.ref_name }}"
+          body: |
+            Automated update of Homebrew formula for release ${{ github.ref_name }}
+            
+            SHA256 checksums:
+            - darwin-arm64: ${{ steps.sha256.outputs.darwin_arm64 }}
+            - darwin-x64: ${{ steps.sha256.outputs.darwin_x64 }}
+            - linux-arm64: ${{ steps.sha256.outputs.linux_arm64 }}
+            - linux-x64: ${{ steps.sha256.outputs.linux_x64 }}
+          branch: update-homebrew-${{ github.ref_name }}
+          delete-branch: true

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 
 # Claude working directory
 .claude
+
+# Test downloads
+*.tar.gz.bak

--- a/README.md
+++ b/README.md
@@ -64,7 +64,14 @@ Choose [mcp-atlassian](https://github.com/sooperset/mcp-atlassian) if you:
 
 ## Installation
 
-### Option 1: Install via npm (Recommended)
+### Option 1: Install via Homebrew (macOS/Linux)
+
+```bash
+brew tap choplin/jira-cli-mcp
+brew install jira-cli-mcp
+```
+
+### Option 2: Install via npm
 
 ```bash
 # Install globally with npm
@@ -74,7 +81,7 @@ npm install -g @choplin/jira-cli-mcp
 bun install -g @choplin/jira-cli-mcp
 ```
 
-### Option 2: Download Binary
+### Option 3: Download Binary
 
 Download the pre-compiled binary for your platform from the [releases page](https://github.com/choplin/jira-cli-mcp/releases):
 
@@ -90,7 +97,7 @@ chmod +x jira-cli-mcp-darwin-arm64
 sudo mv jira-cli-mcp-darwin-arm64 /usr/local/bin/jira-cli-mcp
 ```
 
-### Option 3: Build from Source
+### Option 4: Build from Source
 
 ```bash
 git clone https://github.com/choplin/jira-cli-mcp.git

--- a/docs/HOMEBREW_TAP_SETUP.md
+++ b/docs/HOMEBREW_TAP_SETUP.md
@@ -1,0 +1,70 @@
+# Setting up Homebrew Tap for jira-cli-mcp
+
+This guide explains how to set up a Homebrew tap for distributing jira-cli-mcp.
+
+## Prerequisites
+
+- A GitHub account
+- A macOS machine for testing
+
+## Steps
+
+### 1. Create a new repository for your tap
+
+Create a new repository named `homebrew-jira-cli-mcp` on GitHub. Homebrew taps must follow the naming convention `homebrew-*`.
+
+### 2. Add the formula
+
+Copy the `homebrew/jira-cli-mcp.rb` file from this repository to your tap repository.
+
+### 3. Test the formula locally
+
+```bash
+# Clone your tap
+git clone https://github.com/choplin/homebrew-jira-cli-mcp.git
+cd homebrew-jira-cli-mcp
+
+# Test the formula
+brew install --build-from-source ./jira-cli-mcp.rb
+```
+
+### 4. Publish your tap
+
+Push the formula to your GitHub repository:
+
+```bash
+git add jira-cli-mcp.rb
+git commit -m "Add jira-cli-mcp formula"
+git push origin main
+```
+
+### 5. Users can now install via Homebrew
+
+```bash
+# Add your tap
+brew tap choplin/jira-cli-mcp
+
+# Install the formula
+brew install jira-cli-mcp
+```
+
+## Automation
+
+The GitHub Actions workflow in this repository will automatically:
+
+1. Calculate SHA256 checksums for each binary
+2. Update the formula with the correct version and checksums
+3. Create a PR to update the formula
+
+## Alternative: Homebrew Core
+
+For wider distribution, you can submit the formula to homebrew-core:
+
+1. Fork https://github.com/Homebrew/homebrew-core
+2. Add your formula to `Formula/j/jira-cli-mcp.rb`
+3. Submit a pull request
+
+Note: Homebrew core has stricter requirements:
+- Must have at least 50 GitHub stars
+- Must be a stable release (no pre-releases)
+- Must pass all Homebrew tests

--- a/docs/PACKAGE_MANAGERS.md
+++ b/docs/PACKAGE_MANAGERS.md
@@ -1,0 +1,98 @@
+# Package Manager Distribution
+
+This document outlines how to distribute jira-cli-mcp through various package managers.
+
+## Current Support
+
+### Homebrew (macOS/Linux)
+- Status: ✅ Implemented
+- Installation: `brew tap choplin/jira-cli-mcp && brew install jira-cli-mcp`
+- Formula location: `homebrew/jira-cli-mcp.rb`
+
+## Future Package Managers
+
+### AUR (Arch Linux)
+- Status: 📋 Planned
+- Package name: `jira-cli-mcp-bin`
+- Required files:
+  - `PKGBUILD`
+  - `.SRCINFO`
+
+Example PKGBUILD:
+```bash
+pkgname=jira-cli-mcp-bin
+pkgver=0.1.0
+pkgrel=1
+pkgdesc="MCP server that wraps jira-cli for AI assistants"
+arch=('x86_64' 'aarch64')
+url="https://github.com/choplin/jira-cli-mcp"
+license=('Apache')
+depends=('jira-cli')
+source_x86_64=("https://github.com/choplin/jira-cli-mcp/releases/download/v${pkgver}/jira-cli-mcp-linux-x64.tar.gz")
+source_aarch64=("https://github.com/choplin/jira-cli-mcp/releases/download/v${pkgver}/jira-cli-mcp-linux-arm64.tar.gz")
+
+package() {
+  install -Dm755 "jira-cli-mcp-linux-${CARCH}" "${pkgdir}/usr/bin/jira-cli-mcp"
+}
+```
+
+### Scoop (Windows)
+- Status: 📋 Planned
+- Bucket: `extras` or custom bucket
+- Manifest: `jira-cli-mcp.json`
+
+Example manifest:
+```json
+{
+    "version": "0.1.0",
+    "description": "MCP server that wraps jira-cli for AI assistants",
+    "homepage": "https://github.com/choplin/jira-cli-mcp",
+    "license": "Apache-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/choplin/jira-cli-mcp/releases/download/v0.1.0/jira-cli-mcp-windows-x64.zip",
+            "hash": "sha256:..."
+        }
+    },
+    "bin": "jira-cli-mcp.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/choplin/jira-cli-mcp/releases/download/v$version/jira-cli-mcp-windows-x64.zip"
+            }
+        }
+    }
+}
+```
+
+### APT/DEB (Debian/Ubuntu)
+- Status: 📋 Planned
+- Options:
+  1. PPA (Personal Package Archive)
+  2. Direct .deb download
+  3. Submit to official repositories
+
+### RPM (Fedora/RHEL)
+- Status: 📋 Planned
+- Options:
+  1. COPR repository
+  2. Direct .rpm download
+  3. Submit to official repositories
+
+### Nix
+- Status: 📋 Planned
+- Package in nixpkgs
+- Flake support
+
+## Implementation Priority
+
+1. **Homebrew** ✅ - Complete
+2. **AUR** - Most requested by community
+3. **Scoop** - For Windows users
+4. **Nix** - Growing popularity
+5. **APT/RPM** - Enterprise users
+
+## Automation
+
+Each package manager should be updated automatically via GitHub Actions when a new release is created. The `release.yml` workflow can be extended to handle each package manager.

--- a/homebrew/jira-cli-mcp.rb
+++ b/homebrew/jira-cli-mcp.rb
@@ -1,0 +1,38 @@
+class JiraCliMcp < Formula
+  desc "MCP server that wraps jira-cli for AI assistants"
+  homepage "https://github.com/choplin/jira-cli-mcp"
+  version "0.1.0"
+  license "Apache-2.0"
+
+  on_macos do
+    if Hardware::CPU.arm?
+      url "https://github.com/choplin/jira-cli-mcp/releases/download/v0.1.0/jira-cli-mcp-darwin-arm64.tar.gz"
+      sha256 "PLACEHOLDER_SHA256_DARWIN_ARM64" # darwin-arm64
+    else
+      url "https://github.com/choplin/jira-cli-mcp/releases/download/v0.1.0/jira-cli-mcp-darwin-x64.tar.gz"
+      sha256 "PLACEHOLDER_SHA256_DARWIN_X64" # darwin-x64
+    end
+  end
+
+  on_linux do
+    if Hardware::CPU.arm?
+      url "https://github.com/choplin/jira-cli-mcp/releases/download/v0.1.0/jira-cli-mcp-linux-arm64.tar.gz"
+      sha256 "PLACEHOLDER_SHA256_LINUX_ARM64" # linux-arm64
+    else
+      url "https://github.com/choplin/jira-cli-mcp/releases/download/v0.1.0/jira-cli-mcp-linux-x64.tar.gz"
+      sha256 "PLACEHOLDER_SHA256_LINUX_X64" # linux-x64
+    end
+  end
+
+  depends_on "jira-cli"
+
+  def install
+    binary_name = "jira-cli-mcp-#{OS.kernel_name.downcase}-#{Hardware::CPU.arch}"
+    bin.install binary_name => "jira-cli-mcp"
+  end
+
+  test do
+    # Test that the binary runs
+    assert_match "MCP Server running", shell_output("#{bin}/jira-cli-mcp 2>&1", 1)
+  end
+end

--- a/scripts/update-homebrew-formula.sh
+++ b/scripts/update-homebrew-formula.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# Script to update Homebrew formula with new release information
+
+set -e
+
+if [ "$#" -ne 1 ]; then
+    echo "Usage: $0 <version>"
+    echo "Example: $0 0.1.0"
+    exit 1
+fi
+
+VERSION=$1
+FORMULA_PATH="homebrew/jira-cli-mcp.rb"
+
+echo "Updating Homebrew formula for version $VERSION..."
+
+# Function to get SHA256 for a URL
+get_sha256() {
+    local url=$1
+    local filename=$(basename "$url")
+    
+    echo "Downloading $url..."
+    curl -sL "$url" -o "$filename"
+    
+    local sha256=$(shasum -a 256 "$filename" | awk '{print $1}')
+    rm "$filename"
+    
+    echo "$sha256"
+}
+
+# Base URL for releases
+BASE_URL="https://github.com/choplin/jira-cli-mcp/releases/download/v${VERSION}"
+
+# Get SHA256 for each platform
+echo "Getting SHA256 checksums..."
+DARWIN_ARM64_SHA=$(get_sha256 "${BASE_URL}/jira-cli-mcp-darwin-arm64.tar.gz")
+DARWIN_X64_SHA=$(get_sha256 "${BASE_URL}/jira-cli-mcp-darwin-x64.tar.gz")
+LINUX_ARM64_SHA=$(get_sha256 "${BASE_URL}/jira-cli-mcp-linux-arm64.tar.gz")
+LINUX_X64_SHA=$(get_sha256 "${BASE_URL}/jira-cli-mcp-linux-x64.tar.gz")
+
+# Update formula
+echo "Updating formula..."
+sed -i.bak "s/version \".*\"/version \"$VERSION\"/" "$FORMULA_PATH"
+sed -i.bak "s|download/v[0-9.]*|download/v$VERSION|g" "$FORMULA_PATH"
+sed -i.bak "s/sha256 \"[a-f0-9]*\" # darwin-arm64/sha256 \"$DARWIN_ARM64_SHA\" # darwin-arm64/" "$FORMULA_PATH"
+sed -i.bak "s/sha256 \"[a-f0-9]*\" # darwin-x64/sha256 \"$DARWIN_X64_SHA\" # darwin-x64/" "$FORMULA_PATH"
+sed -i.bak "s/sha256 \"[a-f0-9]*\" # linux-arm64/sha256 \"$LINUX_ARM64_SHA\" # linux-arm64/" "$FORMULA_PATH"
+sed -i.bak "s/sha256 \"[a-f0-9]*\" # linux-x64/sha256 \"$LINUX_X64_SHA\" # linux-x64/" "$FORMULA_PATH"
+
+# Clean up backup files
+rm "${FORMULA_PATH}.bak"
+
+echo "Formula updated successfully!"
+echo ""
+echo "SHA256 checksums:"
+echo "  darwin-arm64: $DARWIN_ARM64_SHA"
+echo "  darwin-x64:   $DARWIN_X64_SHA"
+echo "  linux-arm64:  $LINUX_ARM64_SHA"
+echo "  linux-x64:    $LINUX_X64_SHA"
+echo ""
+echo "Next steps:"
+echo "1. Review the changes: git diff $FORMULA_PATH"
+echo "2. Copy the formula to your homebrew-jira-cli-mcp tap repository"
+echo "3. Commit and push the changes"


### PR DESCRIPTION
## Summary
- Adds Homebrew as the primary package manager for distributing jira-cli-mcp binaries
- Automates formula updates through GitHub Actions
- Documents future package manager support

## Changes

### Homebrew Formula
- Created `homebrew/jira-cli-mcp.rb` with multi-platform support (macOS & Linux, Intel & ARM)
- Formula automatically selects correct binary based on OS and architecture
- Depends on `jira-cli` formula

### GitHub Actions Automation
- Updated release workflow to calculate SHA256 checksums for each binary
- Added automated job to update Homebrew formula on new releases
- Creates PR with updated checksums automatically

### Installation Flow
Users will install via:
```bash
brew tap choplin/jira-cli-mcp
brew install jira-cli-mcp
```

### Documentation
- Added `docs/HOMEBREW_TAP_SETUP.md` - Instructions for setting up the tap repository
- Added `docs/PACKAGE_MANAGERS.md` - Roadmap for future package managers (AUR, Scoop, etc.)
- Updated README to list Homebrew as the primary installation method
- Added `scripts/update-homebrew-formula.sh` for manual formula updates

## Next Steps
1. Create `homebrew-jira-cli-mcp` repository on GitHub
2. Copy the formula to the tap repository
3. Test the installation process
4. Consider submitting to homebrew-core after reaching 50+ stars

## Future Package Managers
Documented plans for:
- AUR (Arch Linux)
- Scoop (Windows)
- APT/DEB (Debian/Ubuntu)
- RPM (Fedora/RHEL)
- Nix