### PR TITLE
fix: use stdin for add_comment and update_ticket_description to handle long content

### DIFF
--- a/src/tools/addComment.ts
+++ b/src/tools/addComment.ts
@@ -19,9 +19,9 @@ export async function addComment(
 ): Promise<AddCommentResult> {
   const { ticketKey, comment } = params;
 
-  // Build command arguments
-  const args = ["issue", "comment", "add", ticketKey, comment, "--no-input"];
-  const result = await executeJiraCommand(args);
+  // Use stdin for comment body to handle multi-line comments and special characters
+  const args = ["issue", "comment", "add", ticketKey, "--no-input"];
+  const result = await executeJiraCommand(args, comment);
 
   if (result.exitCode !== 0) {
     throw new Error(`Failed to add comment to ${ticketKey}: ${result.stderr}`);

--- a/src/tools/updateTicketDescription.ts
+++ b/src/tools/updateTicketDescription.ts
@@ -22,16 +22,9 @@ export async function updateTicketDescription(
 ): Promise<UpdateTicketDescriptionResult> {
   const { ticketKey, description } = params;
 
-  // Build command arguments
-  const args = [
-    "issue",
-    "edit",
-    ticketKey,
-    "--body",
-    description,
-    "--no-input",
-  ];
-  const result = await executeJiraCommand(args);
+  // Use stdin for description to handle multi-line content and special characters
+  const args = ["issue", "edit", ticketKey, "--no-input"];
+  const result = await executeJiraCommand(args, description);
 
   if (result.exitCode !== 0) {
     throw new Error(`Failed to update ticket ${ticketKey}: ${result.stderr}`);

--- a/src/utils/jiraExecutor.ts
+++ b/src/utils/jiraExecutor.ts
@@ -30,7 +30,10 @@ export async function executeJiraCommand(
 
     // Write input to stdin if provided
     if (input) {
-      proc.stdin.write(input);
+      proc.stdin.on("error", (err) => {
+        console.error("Error writing to stdin:", err);
+      });
+      proc.stdin.write(input, "utf-8");
       proc.stdin.end();
     }
 

--- a/src/utils/jiraExecutor.ts
+++ b/src/utils/jiraExecutor.ts
@@ -15,6 +15,7 @@ export class JiraCliError extends Error {
 
 export async function executeJiraCommand(
   args: string[],
+  input?: string,
 ): Promise<CommandResult> {
   const config = getConfig();
   const jiraPath = config.jiraCliPath;
@@ -26,6 +27,12 @@ export async function executeJiraCommand(
     const proc = spawn(jiraPath, args, {
       env: { ...process.env },
     });
+
+    // Write input to stdin if provided
+    if (input) {
+      proc.stdin.write(input);
+      proc.stdin.end();
+    }
 
     proc.stdout.on("data", (chunk) => {
       chunks.push(chunk);

--- a/tests/addComment.test.ts
+++ b/tests/addComment.test.ts
@@ -20,21 +20,23 @@ describe("addComment", () => {
   // Mock tests using recorded output
   describe("unit tests (mocked)", () => {
     test("should add comment successfully", async () => {
-      const mockExecuteJiraCommand = mock(async (args: string[]) => {
-        expect(args).toEqual([
-          "issue",
-          "comment",
-          "add",
-          "TEST-123",
-          "This is a test comment",
-          "--no-input",
-        ]);
-        return {
-          stdout: "✓ Comment added to TEST-123",
-          stderr: "",
-          exitCode: 0,
-        };
-      });
+      const mockExecuteJiraCommand = mock(
+        async (args: string[], input?: string) => {
+          expect(args).toEqual([
+            "issue",
+            "comment",
+            "add",
+            "TEST-123",
+            "--no-input",
+          ]);
+          expect(input).toBe("This is a test comment");
+          return {
+            stdout: "✓ Comment added to TEST-123",
+            stderr: "",
+            exitCode: 0,
+          };
+        },
+      );
 
       mock.module("../src/utils/jiraExecutor", () => ({
         executeJiraCommand: mockExecuteJiraCommand,

--- a/tests/updateTicketDescription.test.ts
+++ b/tests/updateTicketDescription.test.ts
@@ -20,21 +20,17 @@ describe("updateTicketDescription", () => {
   // Mock tests using recorded output
   describe("unit tests (mocked)", () => {
     test("should update ticket description successfully", async () => {
-      const mockExecuteJiraCommand = mock(async (args: string[]) => {
-        expect(args).toEqual([
-          "issue",
-          "edit",
-          "TEST-123",
-          "--body",
-          "This is the new description",
-          "--no-input",
-        ]);
-        return {
-          stdout: "✓ Issue TEST-123 has been updated",
-          stderr: "",
-          exitCode: 0,
-        };
-      });
+      const mockExecuteJiraCommand = mock(
+        async (args: string[], input?: string) => {
+          expect(args).toEqual(["issue", "edit", "TEST-123", "--no-input"]);
+          expect(input).toBe("This is the new description");
+          return {
+            stdout: "✓ Issue TEST-123 has been updated",
+            stderr: "",
+            exitCode: 0,
+          };
+        },
+      );
 
       mock.module("../src/utils/jiraExecutor", () => ({
         executeJiraCommand: mockExecuteJiraCommand,


### PR DESCRIPTION
## Summary
- Fix add_comment hanging with long/multiline comments by using stdin
- Fix update_ticket_description to also use stdin for consistency
- Add proper error handling for stdin operations

## Problem
The `add_comment` function would hang when processing long comments (like the one in `/tmp/mcp-jira-long-comment.txt`) because it was passing the comment as a command line argument, which can cause:
- Shell escaping issues
- Command line length limits
- Problems with special characters and newlines

## Solution
- Modified `executeJiraCommand` to accept optional stdin input
- Updated `addComment` to pass comment via stdin using `jira issue comment add TICKET-KEY` (without the comment as an argument)
- Also updated `updateTicketDescription` to use stdin for consistency
- Added error handling for stdin write operations

## Test plan
- [x] Unit tests updated and passing
- [x] Tested manually with `echo "test" | jira issue comment add DLT-16561` 
- [x] Tested with the actual long comment from `/tmp/mcp-jira-long-comment.txt`
- [ ] Integration test with MCP server

🤖 Generated with [Claude Code](https://claude.ai/code)