### PR TITLE
Fix: Use node shebang for npm distribution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,13 +110,6 @@ jobs:
       - name: Build for npm
         run: bun run build:prod
 
-      - name: Update shebang for Node.js
-        run: |
-          echo '#!/usr/bin/env node' > dist/index.js.tmp
-          cat dist/index.js >> dist/index.js.tmp
-          mv dist/index.js.tmp dist/index.js
-          chmod +x dist/index.js
-
       - name: Test npm package
         run: |
           npm pack

--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
   "scripts": {
     "start": "bun run src/index.ts",
     "dev": "bun --watch run src/index.ts",
-    "build": "rm -rf dist && bun build --target=bun --outdir=dist --sourcemap src/index.ts",
-    "build:prod": "rm -rf dist && bun build --target=bun --outdir=dist --minify --sourcemap=none src/index.ts",
+    "build": "rm -rf dist && bun build --target=node --banner=$'#!/usr/bin/env node\\n' --outdir=dist --sourcemap src/index.ts",
+    "build:prod": "rm -rf dist && bun build --target=node --banner=$'#!/usr/bin/env node\\n' --outdir=dist --minify --sourcemap=none src/index.ts",
     "build:tsc": "rm -rf dist && tsc -p tsconfig.build.json",
     "build:binary:darwin-arm64": "bun build --compile --target=bun-darwin-arm64 --minify --sourcemap=none --outfile=jira-cli-mcp-darwin-arm64 src/index.ts",
     "build:binary:darwin-x64": "bun build --compile --target=bun-darwin-x64 --minify --sourcemap=none --outfile=jira-cli-mcp-darwin-x64 src/index.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,3 @@
-#!/usr/bin/env bun
-
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { addComment, addCommentSchema } from "./tools/addComment.js";


### PR DESCRIPTION
## Summary
- Remove bun shebang from npm package to fix errors for users without bun installed
- Update build configuration to properly generate node-compatible bundles

## Changes
- Removed `#\!/usr/bin/env bun` shebang from `src/index.ts`
- Updated build scripts to use `--target=node` with `--banner` flag to add proper node shebang
- This ensures the distributed npm package works for all users, regardless of whether they have bun installed

## Test plan
- [x] Built the project with `bun run build`
- [x] Verified the output has `#\!/usr/bin/env node` shebang
- [x] Tested that the built file can be executed with node
- [x] All unit tests pass

Fixes #13