### PR TITLE
chore: prepare v0.3.0 release

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,7 +97,14 @@ Add to `claude_desktop_config.json`:
 
 ## Recent Changes
 
-### v0.2.1 (Current)
+### v0.3.0 (Current)
+
+- Changed license from Apache 2.0 to MIT
+- Added tool descriptions and annotations for better discoverability in MCP clients
+- Fixed npm distribution shebang issue for users without bun installed
+- Removed duplicate shebang modification in CI workflow
+
+### v0.2.1
 
 - Fixed JQL ORDER BY error by implementing workaround for jira-cli bug (#11)
   - Removed ORDER BY clause from JQL generation
@@ -117,7 +124,7 @@ Add to `claude_desktop_config.json`:
 ### v0.1.0
 
 - Initial public release with core MCP tools
-- Added Apache License 2.0
+- Added Apache License 2.0 (later changed to MIT in v0.3.0)
 - Added GitHub Actions CI workflow
 - Fixed unit tests to pass without jira-cli installed
 - Added CI status badge to README

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@choplin/jira-cli-mcp",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "MCP server that wraps jira-cli for AI assistants",
   "license": "MIT",
   "author": "Akihiro Okuno",


### PR DESCRIPTION
## Summary
Prepare for v0.3.0 release with significant improvements and license change.

## Changes in v0.3.0
- 🔄 Changed license from Apache 2.0 to MIT
- ✨ Added tool descriptions and annotations for better discoverability in MCP clients
- 🐛 Fixed npm distribution shebang issue for users without bun installed
- 🔧 Removed duplicate shebang modification in CI workflow

## Test plan
- [x] All tests pass
- [x] Build succeeds
- [x] Version bumped to 0.3.0
- [x] CLAUDE.md updated with v0.3.0 changes
- [ ] Will create git tag after merge
- [ ] GitHub Actions will automatically publish to npm and create release