### PR TITLE
feat: add create_ticket tool for creating new Jira tickets

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Choose [mcp-atlassian](https://github.com/sooperset/mcp-atlassian) if you:
 
 ## Features
 
+- **create_ticket** - Create new Jira tickets with customizable fields
 - **list_tickets** - Search and list Jira tickets using JQL queries
 - **get_ticket** - Get detailed ticket information including comments
 - **update_ticket_description** - Update ticket descriptions with rich text formatting

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { addComment, addCommentSchema } from "./tools/addComment.js";
 import { assignToMe, assignToMeSchema } from "./tools/assignToMe.js";
+import { createTicket, createTicketSchema } from "./tools/createTicket.js";
 import { getTicket, getTicketSchema } from "./tools/getTicket.js";
 import { listTickets, listTicketsSchema } from "./tools/listTickets.js";
 import { moveTicket, moveTicketSchema } from "./tools/moveTicket.js";
@@ -315,6 +316,57 @@ server.tool(
           {
             type: "text",
             text: result.message,
+          },
+        ],
+      };
+    } catch (error) {
+      if (error instanceof JiraCliError) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Error: ${error.message}\n\nMake sure jira-cli is installed and authenticated.`,
+            },
+          ],
+        };
+      }
+      throw error;
+    }
+  },
+);
+
+// Create ticket tool
+server.tool(
+  "create_ticket",
+  "Create a new Jira ticket",
+  createTicketSchema.shape,
+  {
+    title: "Create Jira Ticket",
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: false,
+    openWorldHint: true,
+  },
+  async (params) => {
+    try {
+      const result = await createTicket(params);
+
+      if (!result.success) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Failed to create ticket: ${result.error}`,
+            },
+          ],
+        };
+      }
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Successfully created ticket ${result.ticketKey}\nURL: ${result.ticketUrl}`,
           },
         ],
       };

--- a/src/tools/createTicket.ts
+++ b/src/tools/createTicket.ts
@@ -1,0 +1,96 @@
+import { z } from "zod";
+import { executeJiraCommand } from "../utils/jiraExecutor.js";
+import type { CreateTicketParams, CreateTicketResult } from "../utils/types.js";
+
+export const createTicketSchema = z.object({
+  project: z.string().describe("Jira project key (e.g., PROJ)"),
+  type: z.string().describe("Issue type (e.g., Bug, Story, Task)"),
+  summary: z.string().describe("Issue summary/title"),
+  description: z
+    .string()
+    .optional()
+    .describe("Issue description (markdown supported)"),
+  priority: z
+    .string()
+    .optional()
+    .describe("Priority level (e.g., High, Medium, Low)"),
+  assignee: z.string().optional().describe("Assignee username or email"),
+  labels: z.array(z.string()).optional().describe("List of labels to add"),
+  components: z
+    .array(z.string())
+    .optional()
+    .describe("List of components to add"),
+});
+
+export async function createTicket(
+  params: CreateTicketParams,
+): Promise<CreateTicketResult> {
+  const args = [
+    "issue",
+    "create",
+    "--project",
+    params.project,
+    "--type",
+    params.type,
+    "--summary",
+    params.summary,
+    "--no-input",
+    "--raw",
+  ];
+
+  if (params.priority) {
+    args.push("--priority", params.priority);
+  }
+
+  if (params.assignee) {
+    args.push("--assignee", params.assignee);
+  }
+
+  if (params.labels && params.labels.length > 0) {
+    for (const label of params.labels) {
+      args.push("--label", label);
+    }
+  }
+
+  if (params.components && params.components.length > 0) {
+    for (const component of params.components) {
+      args.push("--component", component);
+    }
+  }
+
+  // If description is provided, use stdin with template flag to handle multi-line content
+  const stdin = params.description ? params.description : undefined;
+  if (stdin) {
+    args.push("--template", "-");
+  }
+
+  try {
+    const result = await executeJiraCommand(args, stdin);
+
+    if (result.exitCode !== 0) {
+      return {
+        success: false,
+        error: result.stderr || "Failed to create ticket",
+      };
+    }
+
+    // Parse the JSON output from --raw flag
+    const output = JSON.parse(result.stdout);
+    const ticketKey = output.key;
+    const ticketUrl =
+      output.self ||
+      `${output.fields?.project?.self?.split("/rest/")[0]}/browse/${ticketKey}`;
+
+    return {
+      success: true,
+      ticketKey,
+      ticketUrl,
+    };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    return {
+      success: false,
+      error: `Failed to create ticket: ${errorMessage}`,
+    };
+  }
+}

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -53,3 +53,21 @@ export interface CommandResult {
   stderr: string;
   exitCode: number;
 }
+
+export interface CreateTicketParams {
+  project: string;
+  type: string;
+  summary: string;
+  description?: string;
+  priority?: string;
+  assignee?: string;
+  labels?: string[];
+  components?: string[];
+}
+
+export interface CreateTicketResult {
+  success: boolean;
+  ticketKey?: string;
+  ticketUrl?: string;
+  error?: string;
+}

--- a/tests/createTicket.test.ts
+++ b/tests/createTicket.test.ts
@@ -1,0 +1,190 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { createTicket } from "../src/tools/createTicket.js";
+import * as jiraExecutor from "../src/utils/jiraExecutor.js";
+
+describe("createTicket", () => {
+  beforeEach(() => {
+    mock.restore();
+  });
+
+  test("creates a ticket successfully with minimal params", async () => {
+    const mockResult = {
+      key: "PROJ-123",
+      self: "https://example.atlassian.net/rest/api/2/issue/12345",
+      fields: {
+        project: {
+          self: "https://example.atlassian.net/rest/api/2/project/10000",
+        },
+      },
+    };
+
+    mock.module("../src/utils/jiraExecutor.js", () => ({
+      executeJiraCommand: mock(async () => ({
+        stdout: JSON.stringify(mockResult),
+        stderr: "",
+        exitCode: 0,
+      })),
+    }));
+
+    const result = await createTicket({
+      project: "PROJ",
+      type: "Task",
+      summary: "Test ticket",
+    });
+
+    expect(result).toEqual({
+      success: true,
+      ticketKey: "PROJ-123",
+      ticketUrl: "https://example.atlassian.net/rest/api/2/issue/12345",
+    });
+
+    expect(jiraExecutor.executeJiraCommand).toHaveBeenCalledWith(
+      [
+        "issue",
+        "create",
+        "--project",
+        "PROJ",
+        "--type",
+        "Task",
+        "--summary",
+        "Test ticket",
+        "--no-input",
+        "--raw",
+      ],
+      undefined,
+    );
+  });
+
+  test("creates a ticket with all parameters", async () => {
+    const mockResult = {
+      key: "PROJ-124",
+      self: "https://example.atlassian.net/rest/api/2/issue/12346",
+    };
+
+    mock.module("../src/utils/jiraExecutor.js", () => ({
+      executeJiraCommand: mock(async () => ({
+        stdout: JSON.stringify(mockResult),
+        stderr: "",
+        exitCode: 0,
+      })),
+    }));
+
+    const result = await createTicket({
+      project: "PROJ",
+      type: "Bug",
+      summary: "Bug report",
+      description: "This is a detailed description\nwith multiple lines",
+      priority: "High",
+      assignee: "john.doe",
+      labels: ["bug", "urgent"],
+      components: ["backend", "api"],
+    });
+
+    expect(result).toEqual({
+      success: true,
+      ticketKey: "PROJ-124",
+      ticketUrl: "https://example.atlassian.net/rest/api/2/issue/12346",
+    });
+
+    expect(jiraExecutor.executeJiraCommand).toHaveBeenCalledWith(
+      [
+        "issue",
+        "create",
+        "--project",
+        "PROJ",
+        "--type",
+        "Bug",
+        "--summary",
+        "Bug report",
+        "--no-input",
+        "--raw",
+        "--priority",
+        "High",
+        "--assignee",
+        "john.doe",
+        "--label",
+        "bug",
+        "--label",
+        "urgent",
+        "--component",
+        "backend",
+        "--component",
+        "api",
+        "--template",
+        "-",
+      ],
+      "This is a detailed description\nwith multiple lines",
+    );
+  });
+
+  test("handles creation failure", async () => {
+    mock.module("../src/utils/jiraExecutor.js", () => ({
+      executeJiraCommand: mock(async () => ({
+        stdout: "",
+        stderr: "Error: Project not found",
+        exitCode: 1,
+      })),
+    }));
+
+    const result = await createTicket({
+      project: "INVALID",
+      type: "Task",
+      summary: "Test ticket",
+    });
+
+    expect(result).toEqual({
+      success: false,
+      error: "Error: Project not found",
+    });
+  });
+
+  test("handles JSON parsing error", async () => {
+    mock.module("../src/utils/jiraExecutor.js", () => ({
+      executeJiraCommand: mock(async () => ({
+        stdout: "Invalid JSON",
+        stderr: "",
+        exitCode: 0,
+      })),
+    }));
+
+    const result = await createTicket({
+      project: "PROJ",
+      type: "Task",
+      summary: "Test ticket",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Failed to create ticket:");
+  });
+
+  test("constructs URL from project self link when ticket self is missing", async () => {
+    const mockResult = {
+      key: "PROJ-125",
+      fields: {
+        project: {
+          self: "https://example.atlassian.net/rest/api/2/project/10000",
+        },
+      },
+    };
+
+    mock.module("../src/utils/jiraExecutor.js", () => ({
+      executeJiraCommand: mock(async () => ({
+        stdout: JSON.stringify(mockResult),
+        stderr: "",
+        exitCode: 0,
+      })),
+    }));
+
+    const result = await createTicket({
+      project: "PROJ",
+      type: "Task",
+      summary: "Test ticket",
+    });
+
+    expect(result).toEqual({
+      success: true,
+      ticketKey: "PROJ-125",
+      ticketUrl: "https://example.atlassian.net/browse/PROJ-125",
+    });
+  });
+});

--- a/tests/integration/createTicket.integration.test.ts
+++ b/tests/integration/createTicket.integration.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { createTicket } from "../../src/tools/createTicket.js";
+import { executeJiraCommand } from "../../src/utils/jiraExecutor.js";
+
+const shouldRunIntegrationTests = process.env.INTEGRATION_TEST === "true";
+const testTicket = process.env.JIRA_CLI_MCP_TEST_TICKET;
+
+describe.skipIf(!shouldRunIntegrationTests)(
+  "createTicket integration tests",
+  () => {
+    let createdTickets: string[] = [];
+
+    afterEach(async () => {
+      // Clean up created tickets by adding a comment
+      for (const ticketKey of createdTickets) {
+        try {
+          await executeJiraCommand([
+            "issue",
+            "comment",
+            "add",
+            ticketKey,
+            "--comment",
+            "[Integration Test] This ticket was created by automated tests and can be deleted",
+          ]);
+        } catch (error) {
+          console.error(`Failed to comment on ${ticketKey}:`, error);
+        }
+      }
+      createdTickets = [];
+    });
+
+    test("creates a ticket with minimal parameters", async () => {
+      // First get project key from test ticket
+      const testResult = await executeJiraCommand([
+        "issue",
+        "view",
+        testTicket || "PROJ-1",
+        "--raw",
+      ]);
+      const testTicketData = JSON.parse(testResult.stdout);
+      const projectKey = testTicketData.fields.project.key;
+
+      const result = await createTicket({
+        project: projectKey,
+        type: "Task",
+        summary: "[Integration Test] Minimal ticket creation test",
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.ticketKey).toBeTruthy();
+      expect(result.ticketUrl).toBeTruthy();
+
+      if (result.ticketKey) {
+        createdTickets.push(result.ticketKey);
+
+        // Verify the ticket was created
+        const verifyResult = await executeJiraCommand([
+          "issue",
+          "view",
+          result.ticketKey,
+          "--raw",
+        ]);
+        const ticketData = JSON.parse(verifyResult.stdout);
+
+        expect(ticketData.key).toBe(result.ticketKey);
+        expect(ticketData.fields.summary).toBe(
+          "[Integration Test] Minimal ticket creation test",
+        );
+        expect(ticketData.fields.issuetype.name).toBe("Task");
+      }
+    });
+
+    test("creates a ticket with all parameters", async () => {
+      // First get project key and current user
+      const testResult = await executeJiraCommand([
+        "issue",
+        "view",
+        testTicket || "PROJ-1",
+        "--raw",
+      ]);
+      const testTicketData = JSON.parse(testResult.stdout);
+      const projectKey = testTicketData.fields.project.key;
+
+      const meResult = await executeJiraCommand(["me"]);
+      const currentUser = meResult.stdout.trim();
+
+      const result = await createTicket({
+        project: projectKey,
+        type: "Bug",
+        summary: "[Integration Test] Full ticket creation test",
+        description:
+          "This is a test ticket created by integration tests.\n\nIt includes:\n- Multiple lines\n- Markdown formatting\n- **Bold text**",
+        priority: "Low",
+        assignee: currentUser,
+        labels: ["integration-test", "automated"],
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.ticketKey).toBeTruthy();
+      expect(result.ticketUrl).toBeTruthy();
+
+      if (result.ticketKey) {
+        createdTickets.push(result.ticketKey);
+
+        // Verify the ticket was created with all fields
+        const verifyResult = await executeJiraCommand([
+          "issue",
+          "view",
+          result.ticketKey,
+          "--raw",
+        ]);
+        const ticketData = JSON.parse(verifyResult.stdout);
+
+        expect(ticketData.key).toBe(result.ticketKey);
+        expect(ticketData.fields.summary).toBe(
+          "[Integration Test] Full ticket creation test",
+        );
+        expect(ticketData.fields.issuetype.name).toBe("Bug");
+        expect(ticketData.fields.priority.name).toBe("Low");
+        expect(ticketData.fields.assignee?.displayName).toBeTruthy();
+        expect(ticketData.fields.labels).toContain("integration-test");
+        expect(ticketData.fields.labels).toContain("automated");
+      }
+    });
+
+    test("handles invalid project gracefully", async () => {
+      const result = await createTicket({
+        project: "INVALID_PROJECT_KEY_123",
+        type: "Task",
+        summary: "[Integration Test] This should fail",
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBeTruthy();
+      expect(result.ticketKey).toBeUndefined();
+    });
+
+    test("handles invalid issue type gracefully", async () => {
+      // First get project key from test ticket
+      const testResult = await executeJiraCommand([
+        "issue",
+        "view",
+        testTicket || "PROJ-1",
+        "--raw",
+      ]);
+      const testTicketData = JSON.parse(testResult.stdout);
+      const projectKey = testTicketData.fields.project.key;
+
+      const result = await createTicket({
+        project: projectKey,
+        type: "InvalidIssueType",
+        summary: "[Integration Test] This should fail",
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBeTruthy();
+      expect(result.ticketKey).toBeUndefined();
+    });
+  },
+);


### PR DESCRIPTION
## Summary
- Add new `create_ticket` tool to enable creation of Jira tickets through MCP
- Support all common ticket fields including project, type, summary, description, priority, assignee, labels, and components
- Use `--template` flag to properly handle multi-line descriptions via stdin

## Changes
- Add `createTicket.ts` implementation that wraps `jira issue create` command
- Add type definitions for `CreateTicketParams` and `CreateTicketResult`
- Register the tool in the MCP server with appropriate metadata
- Add comprehensive unit tests with mocking
- Add integration tests for real jira-cli interactions
- Update README to include the new feature

## Test plan
- [x] Unit tests pass
- [x] Build succeeds
- [x] Type checking passes
- [x] Manual testing: Create a ticket with minimal parameters
- [x] Manual testing: Create a ticket with all parameters including description
- [x] Manual testing: Verify error handling for invalid project/type

🤖 Generated with [Claude Code](https://claude.ai/code)