### PR TITLE
feat: add canceled status to JIRA_STATUS_VALUES and mappings

### DIFF
--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -5,6 +5,7 @@ export const JIRA_STATUS_VALUES = [
   "in review",
   "done",
   "closed",
+  "canceled",
   "todo",
   "to do",
 ] as const;
@@ -17,6 +18,7 @@ export const JIRA_STATUS_MAP: Record<JiraStatusValue, string> = {
   "in review": "In Review",
   done: "Done",
   closed: "Closed",
+  canceled: "Canceled",
   todo: "To Do",
   "to do": "To Do",
 };


### PR DESCRIPTION
## Summary
- Add "canceled" status to the list of supported status values
- Enable moveTicket tool to support canceled status transitions

## Changes
- Add "canceled" to `JIRA_STATUS_VALUES` enum
- Add mapping for "canceled" -> "Canceled" in `JIRA_STATUS_MAP`

## Context
During testing, we discovered that some Jira projects have a "Canceled" status that was not supported by the moveTicket tool. This change adds support for this common status value.

## Test plan
- [x] Unit tests pass
- [x] Build succeeds
- [x] Type checking passes
- [ ] Manual testing: Move a ticket to "canceled" status