### PR TITLE
chore: prepare v0.4.0 release

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,7 +97,15 @@ Add to `claude_desktop_config.json`:
 
 ## Recent Changes
 
-### v0.3.0 (Current)
+### v0.4.0 (Current)
+
+- Added `create_ticket` tool - Create new Jira tickets with customizable fields
+  - Support for project, type, summary, description, priority, assignee, labels, and components
+  - Fixed description handling using `--template` flag for proper multi-line support
+- Added "canceled" status to JIRA_STATUS_VALUES and mappings
+  - Enables moveTicket tool to support canceled status transitions
+
+### v0.3.0
 
 - Changed license from Apache 2.0 to MIT
 - Added tool descriptions and annotations for better discoverability in MCP clients

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@choplin/jira-cli-mcp",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "MCP server that wraps jira-cli for AI assistants",
   "license": "MIT",
   "author": "Akihiro Okuno",


### PR DESCRIPTION
## Summary
Release v0.4.0 with new features:
- Add `create_ticket` tool for creating new Jira tickets
- Add "canceled" status support to `moveTicket` tool

## Changes
- Bump version to 0.4.0 in package.json
- Update CLAUDE.md with v0.4.0 changelog

## Features in v0.4.0
- **create_ticket** tool - Create new Jira tickets with customizable fields
  - Support for project, type, summary, description, priority, assignee, labels, and components
  - Fixed description handling using `--template` flag for proper multi-line support
- **canceled status** - Added to JIRA_STATUS_VALUES and mappings
  - Enables moveTicket tool to support canceled status transitions